### PR TITLE
feat(core): diff command for comparing run event sequences

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "TS_NODE_PROJECT=tsconfig.build.json node --require ts-node/register --test src/index.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ClankaKernel } from './runtime/kernel.js';
+import { diffRuns, formatDiffMarkdown } from './diff.js';
 
 const RUNS_DIR = path.resolve(process.cwd(), 'runs');
 
@@ -14,6 +15,7 @@ function usage() {
   console.log('  verify <runId>');
   console.log('  ls');
   console.log('  export <runId>');
+  console.log('  diff <runId1> <runId2> [--json]');
 }
 
 function runPath(runId: string): string {
@@ -100,6 +102,17 @@ function cmdLs() {
   }
 }
 
+function cmdDiff(runId1: string, runId2: string, jsonOutput: boolean) {
+  const kernel1 = loadRun(runId1);
+  const kernel2 = loadRun(runId2);
+  const result = diffRuns(runId1, kernel1.getHistory(), runId2, kernel2.getHistory());
+  if (jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatDiffMarkdown(result));
+  }
+}
+
 function cmdExport(runId: string) {
   const filePath = runPath(runId);
   if (!fs.existsSync(filePath)) {
@@ -148,6 +161,15 @@ async function main() {
     const runId = args[0];
     if (!runId) throw new Error('export requires <runId>');
     cmdExport(runId);
+    return;
+  }
+
+  if (command === 'diff') {
+    const positional = args.filter(a => !a.startsWith('--'));
+    const jsonOutput = args.includes('--json');
+    const [runId1, runId2] = positional;
+    if (!runId1 || !runId2) throw new Error('diff requires <runId1> <runId2>');
+    cmdDiff(runId1, runId2, jsonOutput);
     return;
   }
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,150 @@
+import type { CognitiveEvent } from './runtime/kernel.js';
+
+export interface FieldDiff {
+  field: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export interface ModifiedEvent {
+  seq: number;
+  type: string;
+  event1: CognitiveEvent;
+  event2: CognitiveEvent;
+  fieldDiffs: FieldDiff[];
+}
+
+export interface RunDiffResult {
+  runId1: string;
+  runId2: string;
+  onlyInRun1: CognitiveEvent[];
+  onlyInRun2: CognitiveEvent[];
+  modified: ModifiedEvent[];
+}
+
+function flattenPayload(obj: unknown, prefix = ''): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (obj === null || typeof obj !== 'object') {
+    result[prefix || '.'] = obj;
+    return result;
+  }
+  if (Array.isArray(obj)) {
+    result[prefix] = JSON.stringify(obj);
+    return result;
+  }
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(result, flattenPayload(value, fullKey));
+    } else {
+      result[fullKey] = value;
+    }
+  }
+  return result;
+}
+
+function compareEvents(e1: CognitiveEvent, e2: CognitiveEvent): FieldDiff[] {
+  const diffs: FieldDiff[] = [];
+
+  // Compare type
+  if (e1.type !== e2.type) {
+    diffs.push({ field: 'type', oldValue: e1.type, newValue: e2.type });
+  }
+
+  // Compare causes as serialized arrays
+  if (JSON.stringify(e1.causes) !== JSON.stringify(e2.causes)) {
+    diffs.push({ field: 'causes', oldValue: e1.causes, newValue: e2.causes });
+  }
+
+  // Compare payload fields (flattened)
+  const flat1 = flattenPayload(e1.payload, 'payload');
+  const flat2 = flattenPayload(e2.payload, 'payload');
+  const allKeys = new Set([...Object.keys(flat1), ...Object.keys(flat2)]);
+  for (const key of [...allKeys].sort()) {
+    const v1 = flat1[key];
+    const v2 = flat2[key];
+    if (JSON.stringify(v1) !== JSON.stringify(v2)) {
+      diffs.push({ field: key, oldValue: v1, newValue: v2 });
+    }
+  }
+
+  return diffs;
+}
+
+export function diffRuns(
+  runId1: string,
+  events1: CognitiveEvent[],
+  runId2: string,
+  events2: CognitiveEvent[],
+): RunDiffResult {
+  const map1 = new Map(events1.map(e => [e.seq, e]));
+  const map2 = new Map(events2.map(e => [e.seq, e]));
+
+  const onlyInRun1: CognitiveEvent[] = [];
+  const onlyInRun2: CognitiveEvent[] = [];
+  const modified: ModifiedEvent[] = [];
+
+  const allSeqs = new Set([...map1.keys(), ...map2.keys()]);
+  for (const seq of [...allSeqs].sort((a, b) => a - b)) {
+    const e1 = map1.get(seq);
+    const e2 = map2.get(seq);
+    if (e1 && !e2) {
+      onlyInRun1.push(e1);
+    } else if (!e1 && e2) {
+      onlyInRun2.push(e2);
+    } else if (e1 && e2) {
+      const fieldDiffs = compareEvents(e1, e2);
+      if (fieldDiffs.length > 0) {
+        modified.push({ seq, type: e1.type, event1: e1, event2: e2, fieldDiffs });
+      }
+    }
+  }
+
+  return { runId1, runId2, onlyInRun1, onlyInRun2, modified };
+}
+
+function payloadSummary(payload: unknown): string {
+  const s = JSON.stringify(payload);
+  return s.length > 80 ? s.slice(0, 77) + '...' : s;
+}
+
+export function formatDiffMarkdown(diff: RunDiffResult): string {
+  const lines: string[] = [];
+  lines.push(`## Run Diff: ${diff.runId1} vs ${diff.runId2}`);
+  lines.push('');
+
+  lines.push(`### Only in ${diff.runId1} (${diff.onlyInRun1.length} events)`);
+  if (diff.onlyInRun1.length === 0) {
+    lines.push('_none_');
+  } else {
+    for (const e of diff.onlyInRun1) {
+      lines.push(`- [${e.type}] ${payloadSummary(e.payload)}`);
+    }
+  }
+  lines.push('');
+
+  lines.push(`### Only in ${diff.runId2} (${diff.onlyInRun2.length} events)`);
+  if (diff.onlyInRun2.length === 0) {
+    lines.push('_none_');
+  } else {
+    for (const e of diff.onlyInRun2) {
+      lines.push(`- [${e.type}] ${payloadSummary(e.payload)}`);
+    }
+  }
+  lines.push('');
+
+  lines.push(`### Modified events (${diff.modified.length} events)`);
+  if (diff.modified.length === 0) {
+    lines.push('_none_');
+  } else {
+    for (const m of diff.modified) {
+      for (const fd of m.fieldDiffs) {
+        lines.push(
+          `- [${m.type}]: ${fd.field} changed ${JSON.stringify(fd.oldValue)} → ${JSON.stringify(fd.newValue)}`,
+        );
+      }
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { diffRuns, formatDiffMarkdown } from './diff';
+import type { CognitiveEvent } from './runtime/kernel';
+
+function makeEvent(overrides: Partial<CognitiveEvent> & { seq: number; type: string }): CognitiveEvent {
+  return {
+    v: 1.1,
+    id: `id-${overrides.seq}`,
+    runId: 'run-test',
+    timestamp: 1000 + overrides.seq,
+    causes: [],
+    payload: {},
+    ...overrides,
+  };
+}
+
+test('identical runs produce no diffs', () => {
+  const events: CognitiveEvent[] = [
+    makeEvent({ seq: 0, type: 'run.start' }),
+    makeEvent({ seq: 1, type: 'run.commit' }),
+  ];
+  const result = diffRuns('r1', events, 'r2', events);
+  assert.equal(result.onlyInRun1.length, 0);
+  assert.equal(result.onlyInRun2.length, 0);
+  assert.equal(result.modified.length, 0);
+});
+
+test('extra events in run1 appear in onlyInRun1', () => {
+  const shared: CognitiveEvent[] = [makeEvent({ seq: 0, type: 'run.start' })];
+  const extra = makeEvent({ seq: 1, type: 'tool.call', payload: { tool: 'bash' } });
+  const result = diffRuns('r1', [...shared, extra], 'r2', shared);
+  assert.equal(result.onlyInRun1.length, 1);
+  assert.equal(result.onlyInRun1[0].type, 'tool.call');
+  assert.equal(result.onlyInRun2.length, 0);
+  assert.equal(result.modified.length, 0);
+});
+
+test('extra events in run2 appear in onlyInRun2', () => {
+  const shared: CognitiveEvent[] = [makeEvent({ seq: 0, type: 'run.start' })];
+  const extra = makeEvent({ seq: 1, type: 'tool.result', payload: { output: 'ok' } });
+  const result = diffRuns('r1', shared, 'r2', [...shared, extra]);
+  assert.equal(result.onlyInRun1.length, 0);
+  assert.equal(result.onlyInRun2.length, 1);
+  assert.equal(result.onlyInRun2[0].type, 'tool.result');
+  assert.equal(result.modified.length, 0);
+});
+
+test('payload change detected as modified event', () => {
+  const e1 = makeEvent({ seq: 0, type: 'tool.call', payload: { tool: 'bash', cmd: 'ls' } });
+  const e2 = makeEvent({ seq: 0, type: 'tool.call', payload: { tool: 'bash', cmd: 'pwd' } });
+  const result = diffRuns('r1', [e1], 'r2', [e2]);
+  assert.equal(result.modified.length, 1);
+  const mod = result.modified[0];
+  assert.equal(mod.seq, 0);
+  assert.equal(mod.type, 'tool.call');
+  const cmdDiff = mod.fieldDiffs.find(fd => fd.field === 'payload.cmd');
+  assert.ok(cmdDiff, 'expected payload.cmd field diff');
+  assert.equal(cmdDiff.oldValue, 'ls');
+  assert.equal(cmdDiff.newValue, 'pwd');
+});
+
+test('type change detected as modified event', () => {
+  const e1 = makeEvent({ seq: 0, type: 'run.start' });
+  const e2 = makeEvent({ seq: 0, type: 'run.abort' });
+  const result = diffRuns('r1', [e1], 'r2', [e2]);
+  assert.equal(result.modified.length, 1);
+  const typeDiff = result.modified[0].fieldDiffs.find(fd => fd.field === 'type');
+  assert.ok(typeDiff);
+  assert.equal(typeDiff.oldValue, 'run.start');
+  assert.equal(typeDiff.newValue, 'run.abort');
+});
+
+test('empty runs produce no diffs', () => {
+  const result = diffRuns('r1', [], 'r2', []);
+  assert.equal(result.onlyInRun1.length, 0);
+  assert.equal(result.onlyInRun2.length, 0);
+  assert.equal(result.modified.length, 0);
+});
+
+test('nested payload fields flattened and diffed', () => {
+  const e1 = makeEvent({ seq: 0, type: 'agent.think', payload: { context: { tokens: 100 } } });
+  const e2 = makeEvent({ seq: 0, type: 'agent.think', payload: { context: { tokens: 200 } } });
+  const result = diffRuns('r1', [e1], 'r2', [e2]);
+  assert.equal(result.modified.length, 1);
+  const tokenDiff = result.modified[0].fieldDiffs.find(fd => fd.field === 'payload.context.tokens');
+  assert.ok(tokenDiff, 'expected nested payload.context.tokens diff');
+  assert.equal(tokenDiff.oldValue, 100);
+  assert.equal(tokenDiff.newValue, 200);
+});
+
+test('formatDiffMarkdown contains section headers', () => {
+  const e1 = makeEvent({ seq: 0, type: 'run.start' });
+  const e2 = makeEvent({ seq: 0, type: 'run.start' });
+  const e3 = makeEvent({ seq: 1, type: 'only.in.run1' });
+  const e4 = makeEvent({ seq: 2, type: 'only.in.run2' });
+  const result = diffRuns('alpha', [e1, e3], 'beta', [e2, e4]);
+  const md = formatDiffMarkdown(result);
+  assert.ok(md.includes('## Run Diff: alpha vs beta'));
+  assert.ok(md.includes('### Only in alpha'));
+  assert.ok(md.includes('### Only in beta'));
+  assert.ok(md.includes('### Modified events'));
+  assert.ok(md.includes('[only.in.run1]'));
+  assert.ok(md.includes('[only.in.run2]'));
+});
+
+test('formatDiffMarkdown shows _none_ for empty sections', () => {
+  const events = [makeEvent({ seq: 0, type: 'run.start' })];
+  const result = diffRuns('r1', events, 'r2', events);
+  const md = formatDiffMarkdown(result);
+  assert.equal((md.match(/_none_/g) ?? []).length, 3);
+});
+
+test('formatDiffMarkdown shows field change arrow for modified events', () => {
+  const e1 = makeEvent({ seq: 0, type: 'tool.call', payload: { cmd: 'ls' } });
+  const e2 = makeEvent({ seq: 0, type: 'tool.call', payload: { cmd: 'pwd' } });
+  const result = diffRuns('r1', [e1], 'r2', [e2]);
+  const md = formatDiffMarkdown(result);
+  assert.ok(md.includes('→'), 'expected → arrow in diff output');
+  assert.ok(md.includes('"ls"'));
+  assert.ok(md.includes('"pwd"'));
+});


### PR DESCRIPTION
Adds `clanka-core diff <run1> <run2>` — compares event sequences and highlights payload changes.
## Summary
- New `src/diff.ts` module with `diffRuns()` (matches events by seq, compares type/causes/payload) and `formatDiffMarkdown()` for human-readable output
- `--json` flag for machine-readable output
- 10 unit tests in `src/index.test.ts` covering identical runs, only-in-run1/2, modified events, nested payload flattening, and markdown formatting
- Test script wired via ts-node + Node 18+ built-in test runner
## Test plan
- [ ] `npm run build` passes (TypeScript strict, no errors)
- [ ] `npm test` — 10/10 tests pass
- [ ] `clanka-core diff <runId1> <runId2>` produces markdown diff
- [ ] `clanka-core diff <runId1> <runId2> --json` produces JSON diff
🤖 Generated with [Claude Code](https://claude.com/claude-code)