### PR TITLE
feat: runtime/ coverage, diff.ts tests, publishConfig (98 tests)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -14,6 +14,40 @@ Payload contract in EventLog:
 - `packages/core/event.ts` defines `payload` as `Record<string, any>`.
 - Required payload fields below are therefore `none` unless explicitly stated.
 
+## Coverage checklist
+
+The sections in this file explicitly cover all currently defined event enums/unions with:
+- required fields
+- optional fields
+- example payloads
+
+`packages/core/event.ts` (`EventTypeSchema`) coverage:
+- `run.started`
+- `run.finished`
+- `run.commit`
+- `agent.started`
+- `agent.finished`
+- `model.requested`
+- `model.responded`
+- `tool.requested`
+- `tool.responded`
+- `fs.snapshot`
+- `fs.diff`
+- `decision.made`
+- `invariant.failed`
+- `budget.exhausted`
+
+`packages/core/types.ts` (`EventSchema` discriminated union) coverage:
+- `run.started`
+- `run.finished`
+- `decision.made`
+- `tool.requested`
+- `tool.responded`
+- `fs.diff`
+- `fs.snapshot`
+- `invariant.failed`
+- `error.raised`
+
 ## run.started
 - Required fields: none
 - Optional fields: any payload keys (commonly `name`, `version`)

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,6 +1,19 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { diffLines, formatLineDiff, truncateDiffLines } from './diff';
+import { diffLines, formatLineDiff, truncateDiffLines, diffRuns, formatDiffMarkdown } from './diff';
+import type { CognitiveEvent } from './runtime/kernel';
+
+function makeEvent(overrides: Partial<CognitiveEvent> & { seq: number; type: string }): CognitiveEvent {
+  return {
+    v: 1.1,
+    id: `id-${overrides.seq}`,
+    runId: 'run-test',
+    timestamp: 1000 + overrides.seq,
+    causes: [],
+    payload: {},
+    ...overrides,
+  };
+}
 
 describe('line diff rendering', () => {
   test('added lines are prefixed with +', () => {
@@ -27,12 +40,57 @@ describe('line diff rendering', () => {
     assert.deepEqual(diffLines('same\ncontent', 'same\ncontent'), []);
     assert.equal(formatLineDiff('same\ncontent', 'same\ncontent'), '');
   });
+
+  test('added lines render exactly with zero context', () => {
+    const result = diffLines(['line-a'], ['line-a', 'line-b'], { contextLines: 0 });
+    assert.deepEqual(result, ['+line-b']);
+  });
+
+  test('removed lines render exactly with zero context', () => {
+    const result = diffLines(['line-a', 'line-b'], ['line-a'], { contextLines: 0 });
+    assert.deepEqual(result, ['-line-b']);
+  });
+
+  test('mixed modified+added lines include ellipsis when context is omitted', () => {
+    const result = diffLines(
+      ['alpha', 'beta', 'gamma'],
+      ['alpha', 'BETA', 'gamma', 'delta'],
+      { contextLines: 0 },
+    );
+    assert.deepEqual(result, ['-beta', '+BETA', '...', '+delta']);
+  });
+
+  test('binary-like lines with null bytes are diffed without throwing', () => {
+    const result = diffLines(['\u0000\u0001binary'], ['\u0000\u0002binary'], { contextLines: 0 });
+    assert.deepEqual(result, ['-\u0000\u0001binary', '+\u0000\u0002binary']);
+  });
 });
 
 describe('large diff truncation', () => {
   test('truncateDiffLines appends marker when max is exceeded', () => {
     const lines = ['-a', '+b', '-c', '+d'];
     assert.deepEqual(truncateDiffLines(lines, 3, '[cut]'), ['-a', '+b', '[cut]']);
+  });
+
+  test('truncateDiffLines returns only marker when maxLines <= 1', () => {
+    const lines = ['-a', '+b', '-c'];
+    assert.deepEqual(truncateDiffLines(lines, 1, '[cut]'), ['[cut]']);
+    assert.deepEqual(truncateDiffLines(lines, 0, '[cut]'), ['[cut]']);
+  });
+
+  test('formatLineDiff applies default truncation marker for large diffs', () => {
+    const before = Array.from({ length: 8 }, (_, i) => `before-${i}`);
+    const after = Array.from({ length: 8 }, (_, i) => `after-${i}`);
+    const output = formatLineDiff(before, after, { contextLines: 0, maxLines: 3 });
+    const lines = output.split('\n');
+
+    assert.equal(lines.length, 3);
+    assert.equal(lines[2], '... (truncated)');
+  });
+
+  test('formatLineDiff does not truncate when lines are within maxLines', () => {
+    const output = formatLineDiff(['a'], ['b'], { contextLines: 0, maxLines: 4 });
+    assert.equal(output, '-a\n+b');
   });
 
   test('formatLineDiff supports injectable truncation dependencies', () => {
@@ -55,5 +113,43 @@ describe('large diff truncation', () => {
 
     assert.equal(truncateCalled, true);
     assert.equal(output, 'custom');
+  });
+});
+
+describe('binary payload handling', () => {
+  test('diffRuns detects blob digest changes as modified fields', () => {
+    const e1 = makeEvent({
+      seq: 0,
+      type: 'fs.diff',
+      payload: { path: 'image.png', patch: { kind: 'blob', digest: 'sha256:old' } },
+    });
+    const e2 = makeEvent({
+      seq: 0,
+      type: 'fs.diff',
+      payload: { path: 'image.png', patch: { kind: 'blob', digest: 'sha256:new' } },
+    });
+
+    const diff = diffRuns('run-a', [e1], 'run-b', [e2]);
+    assert.equal(diff.modified.length, 1);
+    const digestDiff = diff.modified[0].fieldDiffs.find(fd => fd.field === 'payload.patch.digest');
+    assert.ok(digestDiff);
+    assert.equal(digestDiff.oldValue, 'sha256:old');
+    assert.equal(digestDiff.newValue, 'sha256:new');
+  });
+
+  test('formatDiffMarkdown includes binary blob digest modifications', () => {
+    const e1 = makeEvent({
+      seq: 0,
+      type: 'fs.diff',
+      payload: { path: 'image.png', patch: { kind: 'blob', digest: 'sha256:abc' } },
+    });
+    const e2 = makeEvent({
+      seq: 0,
+      type: 'fs.diff',
+      payload: { path: 'image.png', patch: { kind: 'blob', digest: 'sha256:def' } },
+    });
+
+    const markdown = formatDiffMarkdown(diffRuns('run-a', [e1], 'run-b', [e2]));
+    assert.ok(markdown.includes('payload.patch.digest changed "sha256:abc" → "sha256:def"'));
   });
 });

--- a/src/runtime/kernel.test.ts
+++ b/src/runtime/kernel.test.ts
@@ -4,6 +4,9 @@ import { toCanonical, ClankaKernel } from './kernel';
 import type { CognitiveEvent } from './kernel';
 import { EventSchema } from '../../packages/core/event';
 import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // ---------------------------------------------------------------------------
 // toCanonical()
@@ -76,8 +79,8 @@ test('log: seq numbers are strictly increasing from 0', async () => {
   assert.ok(e2.seq > e1.seq);
 });
 
-function recalcId(event: Omit<CognitiveEvent, 'id'>): string {
-  const { id: _, ...eventWithoutId } = event as Omit<CognitiveEvent, 'id'> & { id?: string };
+function recalcId(event: Record<string, unknown>): string {
+  const { id: _, ...eventWithoutId } = event as Record<string, unknown> & { id?: string };
   return createHash('sha256').update(toCanonical(eventWithoutId)).digest('hex');
 }
 
@@ -171,6 +174,69 @@ test('log: concurrent calls preserve contiguous sequence ordering per kernel', a
   await Promise.all(writes);
 
   assert.deepEqual(kernel.getHistory().map(e => e.seq), Array.from({ length: 25 }, (_, i) => i));
+  assert.equal(kernel.verify().valid, true);
+});
+
+test('verify: throws when the first event sequence is not zero', async () => {
+  const kernel = new ClankaKernel('run-start-seq');
+  await kernel.log('run.start', 'agent', { msg: 'hi' });
+
+  const [first] = kernel.getHistory();
+  const shiftedFirst = { ...first, seq: 1 };
+  kernel.loadHistory([{ ...shiftedFirst, id: recalcId(shiftedFirst) } as CognitiveEvent]);
+
+  assert.throws(() => kernel.verify(), /Sequence gap/);
+});
+
+test('verify: throws when history entries are loaded out of sequence order', async () => {
+  const kernel = new ClankaKernel('run-out-of-order');
+  await kernel.log('run.start', 'agent', {});
+  await kernel.log('run.middle', 'agent', {});
+  await kernel.log('run.end', 'agent', {});
+
+  const [e0, e1, e2] = kernel.getHistory();
+  kernel.loadHistory([e1, e0, e2]);
+
+  assert.throws(() => kernel.verify(), /Sequence gap/);
+});
+
+test('verify: allows replayed events with omitted causes field', async () => {
+  const kernel = new ClankaKernel('run-optional-causes');
+  await kernel.log('run.start', 'agent', { stage: 'start' });
+
+  const [event] = kernel.getHistory();
+  const { causes: _causes, ...withoutCauses } = event as CognitiveEvent & { causes?: string[] };
+  const replayEvent = { ...withoutCauses, id: recalcId(withoutCauses) } as CognitiveEvent;
+
+  const replayKernel = new ClankaKernel('run-optional-causes');
+  replayKernel.loadHistory([replayEvent]);
+
+  assert.equal(replayKernel.verify().valid, true);
+  assert.equal(replayKernel.verify().eventCount, 1);
+});
+
+test('registerInvariant: appends invariant.failed after a violating event with causal link', async () => {
+  const kernel = new ClankaKernel('run-invariant-failure');
+  kernel.registerInvariant({
+    name: 'tool_requires_plan',
+    description: 'tool.requested must be justified by a decision',
+    async check(ctx: { events: CognitiveEvent[] }) {
+      const last = ctx.events[ctx.events.length - 1];
+      if (last?.type === 'tool.requested') {
+        return { valid: false, message: 'missing decision cause', severity: 'error' };
+      }
+      return { valid: true };
+    },
+  });
+
+  const trigger = await kernel.log('tool.requested', 'agent', { tool: 'bash', cmd: 'ls' });
+  const history = kernel.getHistory();
+
+  assert.equal(history.length, 2);
+  assert.equal(history[1].type, 'invariant.failed');
+  assert.equal(history[1].seq, 1);
+  assert.deepEqual(history[1].causes, [trigger.id]);
+  assert.equal(history[1].payload.invariant, 'tool_requires_plan');
   assert.equal(kernel.verify().valid, true);
 });
 
@@ -294,6 +360,52 @@ test('replay: payload key order does not change ids', async () => {
     assert.equal(h2[0].timestamp, fixedNow);
   } finally {
     (Date as unknown as { now: () => number }).now = originalNow;
+  }
+});
+
+test('replay: repeated serialize calls are stable for unchanged history', async () => {
+  const kernel = new ClankaKernel('run-serialize-stable');
+  await kernel.log('run.start', 'agent', { attempt: 1 });
+  await kernel.log('run.end', 'agent', { status: 'ok' });
+
+  const s1 = kernel.serialize();
+  const s2 = kernel.serialize();
+  const s3 = kernel.serialize();
+
+  assert.equal(s1, s2);
+  assert.equal(s2, s3);
+});
+
+test('replay: fromJSONL ignores surrounding blank lines', async () => {
+  const kernel = new ClankaKernel('run-jsonl-blank-lines');
+  await kernel.log('run.start', 'agent', { prompt: 'hello' });
+  await kernel.log('run.end', 'agent', { status: 'ok' });
+
+  const jsonl = `\n${kernel.serialize()}\n\n`;
+  const restored = ClankaKernel.fromJSONL('run-jsonl-blank-lines', jsonl);
+
+  assert.deepEqual(restored.getHistory(), kernel.getHistory());
+  assert.equal(restored.verify().valid, true);
+});
+
+test('replay: loadFromFile restores deterministic history', async () => {
+  const runId = 'run-load-from-file';
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clanka-core-'));
+  const runsDir = path.join(tmpDir, 'runs');
+  fs.mkdirSync(runsDir, { recursive: true });
+
+  try {
+    const kernel = new ClankaKernel(runId);
+    await kernel.log('run.start', 'agent', { source: 'disk' });
+    await kernel.log('run.end', 'agent', { source: 'disk' });
+
+    fs.writeFileSync(path.join(runsDir, `${runId}.jsonl`), `${kernel.serialize()}\n`, 'utf-8');
+
+    const loaded = ClankaKernel.loadFromFile(runId, runsDir);
+    assert.deepEqual(loaded.getHistory(), kernel.getHistory());
+    assert.equal(loaded.verify().valid, true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
@@ -427,6 +539,37 @@ test('EventSchema: rejects wrong field types', () => {
   assert.equal(parsed.success, false);
 });
 
+test('EventSchema: rejects non-string cause IDs', () => {
+  const parsed = EventSchema.safeParse({
+    ...buildValidEvent(),
+    causes: ['valid-cause', 123],
+  });
+  assert.equal(parsed.success, false);
+});
+
+test('EventSchema: rejects malformed meta.tool/meta.model values', () => {
+  const parsed = EventSchema.safeParse({
+    ...buildValidEvent(),
+    meta: { agentId: 'agent-1', tool: 999, model: false },
+  });
+  assert.equal(parsed.success, false);
+});
+
+test('EventSchema: rejects missing payload field', () => {
+  const { payload: _payload, ...withoutPayload } = buildValidEvent();
+  const parsed = EventSchema.safeParse(withoutPayload);
+  assert.equal(parsed.success, false);
+});
+
+test('EventSchema: accepts optional meta.tool/model with causes omitted', () => {
+  const { causes: _causes, ...withoutCauses } = buildValidEvent();
+  const parsed = EventSchema.safeParse({
+    ...withoutCauses,
+    meta: { agentId: 'agent-1', tool: 'bash', model: 'gpt-5' },
+  });
+  assert.equal(parsed.success, true);
+});
+
 // ---------------------------------------------------------------------------
 // Concurrent run isolation
 // ---------------------------------------------------------------------------
@@ -508,4 +651,67 @@ test('concurrent run logging does not leak event ids across histories', async ()
   for (const id of idsA) {
     assert.ok(!idsB.has(id));
   }
+});
+
+test('concurrent runs with identical payloads still produce distinct ids by runId', async () => {
+  const fixedNow = 1700000002000;
+  const originalNow = Date.now;
+  (Date as unknown as { now: () => number }).now = () => fixedNow;
+
+  try {
+    const alpha = new ClankaKernel('run-alpha-same-payload');
+    const beta = new ClankaKernel('run-beta-same-payload');
+
+    const [a, b] = await Promise.all([
+      alpha.log('model.requested', 'agent', { prompt: 'same' }),
+      beta.log('model.requested', 'agent', { prompt: 'same' }),
+    ]);
+
+    assert.notEqual(a.id, b.id);
+    assert.equal(alpha.verify().valid, true);
+    assert.equal(beta.verify().valid, true);
+  } finally {
+    (Date as unknown as { now: () => number }).now = originalNow;
+  }
+});
+
+test('interleaved concurrent runs verify independently', async () => {
+  const alpha = new ClankaKernel('run-alpha-verify');
+  const beta = new ClankaKernel('run-beta-verify');
+
+  await Promise.all([
+    (async () => {
+      for (let i = 0; i < 8; i++) {
+        await alpha.log('agent.think', 'agent-a', { i, run: 'alpha' });
+      }
+    })(),
+    (async () => {
+      for (let i = 0; i < 8; i++) {
+        await beta.log('agent.think', 'agent-b', { i, run: 'beta' });
+      }
+    })(),
+  ]);
+
+  assert.equal(alpha.verify().valid, true);
+  assert.equal(beta.verify().valid, true);
+  assert.deepEqual(alpha.getHistory().map(e => e.seq), Array.from({ length: 8 }, (_, i) => i));
+  assert.deepEqual(beta.getHistory().map(e => e.seq), Array.from({ length: 8 }, (_, i) => i));
+});
+
+test('serialize: each run output only contains its own runId under concurrency', async () => {
+  const alpha = new ClankaKernel('run-alpha-serialize');
+  const beta = new ClankaKernel('run-beta-serialize');
+
+  await Promise.all([
+    alpha.log('run.start', 'agent-a', { run: 'alpha' }),
+    alpha.log('run.end', 'agent-a', { run: 'alpha' }),
+    beta.log('run.start', 'agent-b', { run: 'beta' }),
+    beta.log('run.end', 'agent-b', { run: 'beta' }),
+  ]);
+
+  const alphaEvents = alpha.serialize().split('\n').filter(Boolean).map(line => JSON.parse(line) as CognitiveEvent);
+  const betaEvents = beta.serialize().split('\n').filter(Boolean).map(line => JSON.parse(line) as CognitiveEvent);
+
+  assert.equal(alphaEvents.every(e => e.runId === 'run-alpha-serialize'), true);
+  assert.equal(betaEvents.every(e => e.runId === 'run-beta-serialize'), true);
 });


### PR DESCRIPTION
- runtime/ tests: event ordering invariants, replay determinism, zod rejection, concurrent isolation\n- diff.ts tests: added/removed/modified lines, binary files, large diff truncation\n- CONTRACT.md updated with all event types + example payloads\n- Added `publishConfig: { access: public }` to package.json\n\n98 tests (up from 75)