### PR TITLE
test: expand runtime/diff coverage + document event schema

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -48,6 +48,39 @@ The sections in this file explicitly cover all currently defined event enums/uni
 - `invariant.failed`
 - `error.raised`
 
+### EventLog payload matrix (`packages/core/event.ts`)
+
+| Event type | Required payload fields | Optional payload fields |
+| --- | --- | --- |
+| `run.started` | none | any payload keys (commonly `name`, `version`) |
+| `run.finished` | none | any payload keys (commonly `status`, `commitHash`) |
+| `run.commit` | none | any payload keys |
+| `agent.started` | none | any payload keys |
+| `agent.finished` | none | any payload keys |
+| `model.requested` | none | any payload keys |
+| `model.responded` | none | any payload keys |
+| `tool.requested` | none | any payload keys |
+| `tool.responded` | none | any payload keys |
+| `fs.snapshot` | none | any payload keys |
+| `fs.diff` | none | any payload keys |
+| `decision.made` | none | any payload keys |
+| `invariant.failed` | none | any payload keys (commonly `invariant`, `message`, `severity`, `triggerEventId`) |
+| `budget.exhausted` | none | any payload keys |
+
+### Strict payload matrix (`packages/core/types.ts`)
+
+| Event type | Required payload fields | Optional payload fields |
+| --- | --- | --- |
+| `run.started` | `name`, `version` | none |
+| `run.finished` | `status` | `commitHash` |
+| `decision.made` | `rationale`, `plan` | none |
+| `tool.requested` | `callId`, `txId`, `tool`, `args` | `caps.fsRead`, `caps.fsWrite`, `caps.net` |
+| `tool.responded` | `callId`, `txId`, `output` | `error.code`, `error.message`, `exitCode` |
+| `fs.diff` | `txId`, `path`, `beforeDigest`, `afterDigest`, `patch` | none |
+| `fs.snapshot` | `workspaceHash`, `files[]` (`path`, `digest`, `size`) | `txId` |
+| `invariant.failed` | `invariant`, `message`, `severity` | none |
+| `error.raised` | `code`, `message` | none |
+
 ## run.started
 - Required fields: none
 - Optional fields: any payload keys (commonly `name`, `version`)

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,13 +1,13 @@
 # TASKS.md — clanka-core
-> Last updated: 2026-02-25 | Status: open
+> Last updated: 2026-03-01 | Status: open
 
 ## 🔴 High Priority
-- [ ] **Expand test coverage for `runtime/`** — add tests for: event ordering invariants, replay determinism, invalid event payloads (zod rejection), concurrent run isolation
-- [ ] **Document the event schema** — ensure `CONTRACT.md` covers every event type with required/optional fields and example payloads
+- [x] **Expand test coverage for `runtime/`** — add tests for: event ordering invariants, replay determinism, invalid event payloads (zod rejection), concurrent run isolation
+- [x] **Document the event schema** — ensure `CONTRACT.md` covers every event type with required/optional fields and example payloads
 - [ ] **Publish to npm as `@clankamode/core`** — add `"publishConfig": { "access": "public" }`, CI publish job, `.npmignore`
 
 ## 🟡 Medium Priority
-- [ ] **`diff.ts` — add tests** — write tests for: added/removed/modified lines, binary file handling, large diff truncation
+- [x] **`diff.ts` — add tests** — write tests for: added/removed/modified lines, binary file handling, large diff truncation
 - [ ] **CLI: `replay` command** — `node dist/cli.js replay <runId>` replays a recorded run with event stream + timestamps
 - [ ] **CLI: `export` command** — `node dist/cli.js export <runId> --format json|markdown`
 - [ ] **Add `packages/` sub-package structure** — split into `@clankamode/core-runtime` and `@clankamode/core-cli`

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -64,6 +64,13 @@ describe('line diff rendering', () => {
     const result = diffLines(['\u0000\u0001binary'], ['\u0000\u0002binary'], { contextLines: 0 });
     assert.deepEqual(result, ['-\u0000\u0001binary', '+\u0000\u0002binary']);
   });
+
+  test('single-line modification renders remove/add pair with zero context', () => {
+    const result = diffLines(['alpha', 'bravo', 'charlie'], ['alpha', 'BRAVO', 'charlie'], {
+      contextLines: 0,
+    });
+    assert.deepEqual(result, ['-bravo', '+BRAVO']);
+  });
 });
 
 describe('large diff truncation', () => {
@@ -86,6 +93,18 @@ describe('large diff truncation', () => {
 
     assert.equal(lines.length, 3);
     assert.equal(lines[2], '... (truncated)');
+  });
+
+  test('formatLineDiff uses custom truncation marker for large output', () => {
+    const before = Array.from({ length: 6 }, (_, i) => `before-${i}`);
+    const after = Array.from({ length: 6 }, (_, i) => `after-${i}`);
+    const output = formatLineDiff(before, after, {
+      contextLines: 0,
+      maxLines: 2,
+      truncationMarker: '[snip]',
+    });
+
+    assert.deepEqual(output.split('\n'), ['-before-0', '[snip]']);
   });
 
   test('formatLineDiff does not truncate when lines are within maxLines', () => {
@@ -151,5 +170,18 @@ describe('binary payload handling', () => {
 
     const markdown = formatDiffMarkdown(diffRuns('run-a', [e1], 'run-b', [e2]));
     assert.ok(markdown.includes('payload.patch.digest changed "sha256:abc" → "sha256:def"'));
+  });
+
+  test('formatDiffMarkdown renders binary blob payloads in added/removed sections', () => {
+    const onlyInRun1 = makeEvent({
+      seq: 0,
+      type: 'fs.diff',
+      payload: { path: 'image.png', patch: { kind: 'blob', digest: 'sha256:blob' } },
+    });
+
+    const markdown = formatDiffMarkdown(diffRuns('run-a', [onlyInRun1], 'run-b', []));
+    assert.ok(markdown.includes('- [fs.diff]'));
+    assert.ok(markdown.includes('"kind":"blob"'));
+    assert.ok(markdown.includes('"digest":"sha256:blob"'));
   });
 });

--- a/src/runtime/kernel.vitest.test.ts
+++ b/src/runtime/kernel.vitest.test.ts
@@ -61,6 +61,18 @@ describe('runtime event ordering invariants', () => {
 
     expect(() => kernel.verify()).toThrow(/unknown cause|forward|self-referencing/i);
   });
+
+  it('rejects out-of-order history even when each event digest is intact', async () => {
+    const kernel = new ClankaKernel('run-ordering-out-of-order');
+    await kernel.log('run.start', 'agent', {});
+    await kernel.log('agent.think', 'agent', {});
+    await kernel.log('run.end', 'agent', {});
+
+    const [e0, e1, e2] = kernel.getHistory();
+    kernel.loadHistory([e1, e0, e2]);
+
+    expect(() => kernel.verify()).toThrow(/sequence gap/i);
+  });
 });
 
 describe('runtime replay determinism', () => {
@@ -117,6 +129,23 @@ describe('runtime replay determinism', () => {
     expect(replayA.getHistory()).toEqual(replayB.getHistory());
     expect(replayA.serialize()).toBe(replayB.serialize());
     expect(replayA.verify()).toEqual(replayB.verify());
+  });
+
+  it('ignores surrounding blank lines during replay and remains deterministic', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-28T00:00:00.000Z'));
+
+    const original = new ClankaKernel('run-deterministic-blank-lines');
+    await original.log('run.start', 'agent', { prompt: 'blank-lines' });
+    await original.log('run.end', 'agent', { status: 'ok' });
+
+    const jsonlWithBlanks = `\n${original.serialize()}\n\n`;
+    const replayA = ClankaKernel.fromJSONL('run-deterministic-blank-lines', jsonlWithBlanks);
+    const replayB = ClankaKernel.fromJSONL('run-deterministic-blank-lines', jsonlWithBlanks);
+
+    expect(replayA.getHistory()).toEqual(original.getHistory());
+    expect(replayA.serialize()).toBe(replayB.serialize());
+    expect(replayA.verify()).toEqual({ valid: true, eventCount: 2 });
   });
 });
 
@@ -180,6 +209,37 @@ describe('invalid event payloads (zod rejection)', () => {
       causes: [],
       payload: {},
       meta: { agentId: 42 },
+    };
+
+    const parsed = EventSchema.safeParse(invalid);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects missing payload field via EventSchema', () => {
+    const invalid = {
+      v: 1.1,
+      id: 'abc',
+      runId: 'run-zod',
+      seq: 0,
+      type: 'run.started',
+      timestamp: 1700000000000,
+      causes: [],
+    };
+
+    const parsed = EventSchema.safeParse(invalid);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects non-string cause IDs via EventSchema', () => {
+    const invalid = {
+      v: 1.1,
+      id: 'abc',
+      runId: 'run-zod',
+      seq: 0,
+      type: 'run.started',
+      timestamp: 1700000000000,
+      causes: ['ok', 42],
+      payload: {},
     };
 
     const parsed = EventSchema.safeParse(invalid);
@@ -254,5 +314,31 @@ describe('concurrent run isolation', () => {
     for (const id of idsA) {
       expect(idsB.has(id)).toBe(false);
     }
+  });
+
+  it('verifies each concurrent run independently and keeps serialization isolated', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-28T00:00:00.000Z'));
+
+    const left = new ClankaKernel('run-left');
+    const right = new ClankaKernel('run-right');
+
+    await Promise.all([
+      (async () => {
+        for (let i = 0; i < 6; i++) {
+          await left.log('agent.step', 'agent-left', { i, run: 'left' });
+        }
+      })(),
+      (async () => {
+        for (let i = 0; i < 6; i++) {
+          await right.log('agent.step', 'agent-right', { i, run: 'right' });
+        }
+      })(),
+    ]);
+
+    expect(left.verify()).toEqual({ valid: true, eventCount: 6 });
+    expect(right.verify()).toEqual({ valid: true, eventCount: 6 });
+    expect(left.serialize().includes('"run-right"')).toBe(false);
+    expect(right.serialize().includes('"run-left"')).toBe(false);
   });
 });


### PR DESCRIPTION
Added runtime tests for event ordering, replay determinism, invalid payloads, concurrent isolation. Documented event schema in CONTRACT.md. Added diff.ts tests.