### PR TITLE
chore: add pre-push hook to run tests before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "pre-push: running tests..."
+if ! npm test; then
+  echo "pre-push: tests failed. Push aborted."
+  exit 1
+fi
+
+echo "pre-push: running lint (if configured)..."
+if ! npm run lint --if-present; then
+  echo "pre-push: lint failed. Push aborted."
+  exit 1
+fi
+
+echo "pre-push: checks passed."
+exit 0

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "npx vitest run",
+    "prepare": "git config core.hooksPath .githooks",
     "prepublishOnly": "npm run build && npm test"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add a repository-local pre-push git hook in .githooks/pre-push
- run npm test before push and fail fast on test errors
- run npm run lint --if-present so lint runs only when configured
- add a prepare script to set core.hooksPath to .githooks

## Verification
- npm run prepare
- sh .githooks/pre-push
- git push -u origin chore/pre-push-hook (hook executed and passed)
