### PR TITLE
feat: add @clankamode/core-runtime and @clankamode/core-cli package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 `clanka-core` is the runtime/event kernel for Clanka agent execution traces. It records canonicalized events, verifies invariants, and supports deterministic replay/inspection workflows through both a CLI and reusable core modules.
 
+## Packages
+- `@clankamode/core-runtime` — runtime/event kernel library
+- `@clankamode/core-cli` — CLI entrypoint (`clanka-core`)
+
 ## Stack
 - TypeScript
 - Node.js

--- a/TASKS.md
+++ b/TASKS.md
@@ -10,7 +10,7 @@
 - [x] **`diff.ts` — add tests** — write tests for: added/removed/modified lines, binary file handling, large diff truncation
 - [x] **CLI: `replay` command** — `node dist/cli.js replay <runId>` replays a recorded run with event stream + timestamps
 - [x] **CLI: `export` command** — `node dist/cli.js export <runId> --format json|markdown` (completed 2026-03-04)
-- [ ] **Add `packages/` sub-package structure** — split into `@clankamode/core-runtime` and `@clankamode/core-cli`
+- [x] **Add `packages/` sub-package structure** — split into `@clankamode/core-runtime` and `@clankamode/core-cli` (completed 2026-03-05)
 
 ## 🟢 Low Priority / Nice to Have
 - [x] **`dogfood.ts` / `dogfood-simple.ts` cleanup** — remove superseded scratch scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "@clankamode/core",
+  "name": "@clankamode/core-monorepo",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@clankamode/core",
+      "name": "@clankamode/core-monorepo",
       "version": "1.0.0",
       "license": "ISC",
-      "bin": {
-        "clanka-core": "dist/cli.js"
-      },
+      "workspaces": [
+        "packages/core-runtime",
+        "packages/core-cli"
+      ],
       "devDependencies": {
         "@types/node": "^25.3.3",
         "ts-node": "^10.9.2",
@@ -18,6 +19,14 @@
         "vitest": "^4.0.18",
         "zod": "^4.3.6"
       }
+    },
+    "node_modules/@clankamode/core-cli": {
+      "resolved": "packages/core-cli",
+      "link": true
+    },
+    "node_modules/@clankamode/core-runtime": {
+      "resolved": "packages/core-runtime",
+      "link": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1689,6 +1698,22 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "packages/core-cli": {
+      "name": "@clankamode/core-cli",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@clankamode/core-runtime": "^1.0.0"
+      },
+      "bin": {
+        "clanka-core": "dist/cli.js"
+      }
+    },
+    "packages/core-runtime": {
+      "name": "@clankamode/core-runtime",
+      "version": "1.0.0",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,14 @@
 {
-  "name": "@clankamode/core",
+  "name": "@clankamode/core-monorepo",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "dist/runtime/kernel.js",
   "types": "dist/runtime/kernel.d.ts",
-  "files": [
-    "dist",
-    "README.md"
+  "workspaces": [
+    "packages/core-runtime",
+    "packages/core-cli"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "bin": {
-    "clanka-core": "dist/cli.js"
-  },
   "directories": {
     "example": "examples"
   },

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@clankamode/core-cli",
+  "version": "1.0.0",
+  "description": "CLI for clanka-core runtime",
+  "main": "../../dist/cli.js",
+  "types": "../../dist/cli.d.ts",
+  "bin": {
+    "clanka-core": "../../dist/cli.js"
+  },
+  "files": [
+    "../../dist/cli.js",
+    "../../dist/cli.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "@clankamode/core-runtime": "^1.0.0"
+  }
+}

--- a/packages/core-runtime/package.json
+++ b/packages/core-runtime/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@clankamode/core-runtime",
+  "version": "1.0.0",
+  "description": "Runtime/event kernel for clanka-core",
+  "main": "../../dist/runtime/kernel.js",
+  "types": "../../dist/runtime/kernel.d.ts",
+  "files": [
+    "../../dist/runtime"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "ISC"
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,7 +132,7 @@ function formatExportMarkdown(runId: string, kernel: ClankaKernel): string {
 
   for (const event of events) {
     lines.push(`- [${event.seq}] ${event.type} @ ${new Date(event.timestamp).toISOString()}`);
-    lines.push(`  - actor: ${event.actor}`);
+    lines.push(`  - actor: ${event.meta?.agentId ?? 'unknown'}`);
     lines.push(`  - payload: ${JSON.stringify(event.payload)}`);
   }
 


### PR DESCRIPTION
## Summary
- add `packages/core-runtime/package.json` for the runtime sub-package (`@clankamode/core-runtime`)
- add `packages/core-cli/package.json` for the CLI sub-package (`@clankamode/core-cli`)
- convert root package to a private workspace root with both sub-packages declared
- update README and TASKS to reflect the package split
- fix CLI markdown export typing (`event.meta?.agentId`) so build passes

## Validation
- npm run build
- npm test
