### PR TITLE
chore: scaffold npm publish readiness for @clankamode/core

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,15 @@
-name: Publish NPM Package
+name: Publish NPM Package (Scaffold)
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - package.json
+  workflow_dispatch:
+    inputs:
+      run_publish:
+        description: 'Set to true to run npm publish (disabled by default).'
+        required: false
+        default: 'false'
 
 jobs:
-  publish:
+  publish-scaffold:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,39 +17,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Detect version change
-        id: version_check
-        run: |
-          if ! git cat-file -e HEAD^ 2>/dev/null; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          prev_version="$(git show HEAD^:package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(pkg.version);")"
-          curr_version="$(node -e "process.stdout.write(require('./package.json').version)")"
-
-          if [ "$prev_version" = "$curr_version" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Setup Node 24
-        if: steps.version_check.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        if: steps.version_check.outputs.changed == 'true'
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Package dry run
+        run: npm pack --dry-run
+
       - name: Publish to npm
-        if: steps.version_check.outputs.changed == 'true'
+        if: ${{ inputs.run_publish == 'true' }}
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,17 @@
+# Source and tests
 src/
 tests/
 **/*.test.ts
+
+# Project/task/docs not needed in package tarball
 TASKS.md
 *.md
 !README.md
+
+# Tooling and local artifacts
+.github/
+.githooks/
+runs/
+blobs/
+node_modules/
+*.log

--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ From `packages/core/index.ts`:
 
 Key class:
 - `ClankaKernel` (`packages/core/kernel.ts`) for event logging + invariant checks
+
+## NPM publish readiness scaffold
+- Root package metadata is prepared for `@clankamode/core` with `publishConfig.access=public`.
+- CI scaffold is in `.github/workflows/publish.yml` and runs build/test/pack in dry-run mode.
+- Actual publish remains opt-in via manual workflow dispatch input: `run_publish=true`.


### PR DESCRIPTION
## Summary\n- set root package name to  and added \n- replaced publish workflow with safe scaffold: manual dispatch, build/test/pack dry run, opt-in publish step\n- expanded  for source/tests/tooling artifacts and documented scaffold behavior in README\n\n## Safety\n- no automatic publish on push\n- actual 
> @clankamode/core@1.0.0 prepublishOnly
> npm run build && npm test


> @clankamode/core@1.0.0 build
> tsc -p tsconfig.build.json


> @clankamode/core@1.0.0 test
> npx vitest run


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/clanka/repos/clanka-core[39m

 [32m✓[39m src/diff.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m packages/core/replay.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/core/schema-registry.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/index.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m packages/core/event-store.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/runtime/kernel.vitest.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/runtime/kernel.test.ts [2m([22m[2m55 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/core/logger.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 10[2mms[22m[39m

[2m Test Files [22m [1m[32m8 passed[39m[22m[90m (8)[39m
[2m      Tests [22m [1m[32m152 passed[39m[22m[90m (152)[39m
[2m   Start at [22m 09:02:41
[2m   Duration [22m 182ms[2m (transform 356ms, setup 0ms, import 510ms, tests 61ms, environment 0ms)[22m


> @clankamode/core@1.0.0 prepare
> git config core.hooksPath .githooks only runs when workflow input \n\n## Validation\n- 
> @clankamode/core@1.0.0 build
> tsc -p tsconfig.build.json\n- 
> @clankamode/core@1.0.0 test
> npx vitest run


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/clanka/repos/clanka-core[39m

 [32m✓[39m src/diff.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m packages/core/replay.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/core/schema-registry.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m packages/core/event-store.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/index.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/runtime/kernel.vitest.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/runtime/kernel.test.ts [2m([22m[2m55 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/core/logger.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 9[2mms[22m[39m

[2m Test Files [22m [1m[32m8 passed[39m[22m[90m (8)[39m
[2m      Tests [22m [1m[32m152 passed[39m[22m[90m (152)[39m
[2m   Start at [22m 09:02:43
[2m   Duration [22m 193ms[2m (transform 401ms, setup 0ms, import 574ms, tests 59ms, environment 1ms)[22m\n- 
> @clankamode/core@1.0.0 prepare
> git config core.hooksPath .githooks

clankamode-core-1.0.0.tgz